### PR TITLE
fix: explicit semicolons

### DIFF
--- a/src/endpoints.js
+++ b/src/endpoints.js
@@ -46,7 +46,7 @@ router.get('/launch', verifyToken, tokenExchange, obfuscate, asyncMiddleware(lau
 // router.post('/login/*', asyncMiddleware(openIDLogin));
 router.use('/status', asyncMiddleware((req, res, next) => {
   return res.json('OK').status(200);
-}))
+}));
 
 //Tests
 router.get('/test', asyncMiddleware(testEndpoint));

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -167,7 +167,7 @@ logger.logLevelTester = () => {
 	logLevelTest('error');
 	logLevelTest('warn');
 	logLevelTest('info');
-	logLevelTest('auth')
+	logLevelTest('auth');
 	logLevelTest('debug');
 	logLevelTest('calls');
 
@@ -201,7 +201,7 @@ logger.getCurrentLogFileAsync = () => {
 		  return resolve(arr);
 		});
 	});
-}
+};
 
 logger.getInfoMemoryLogAsync = async (nLines) => {
 	return await memLogTransportInfo.getLogAsync(nLines);


### PR DESCRIPTION
Node's parser will implicitly insert a semicolon when it encounters a newline character in general however this is a dangerous feature since it can mask subtle errors and confuse readers; it should not be relied on.

This PR explicitly inserts semicolons.